### PR TITLE
Override ActiveRecord scoping on record save

### DIFF
--- a/lib/fortify.rb
+++ b/lib/fortify.rb
@@ -8,6 +8,7 @@ require 'fortify/base'
 require 'fortify/activerecord/base'
 require 'fortify/activerecord/relation'
 require 'fortify/activerecord/validation'
+require 'fortify/activerecord/scoping'
 
 module Fortify
   thread_mattr_accessor :user, instance_accessor: false
@@ -18,6 +19,7 @@ module Fortify
 
   class << self
     def activate!
+      ::ActiveRecord::Base.send :include, Fortify::ActiveRecord::Scoping
       ::ActiveRecord::Base.send :include, Fortify::ActiveRecord::Base
       ::ActiveRecord::Relation.send :include, Fortify::ActiveRecord::Relation
       ::ActiveRecord::Base.send :include, Fortify::ActiveRecord::Validation

--- a/lib/fortify/activerecord/scoping.rb
+++ b/lib/fortify/activerecord/scoping.rb
@@ -1,0 +1,11 @@
+module Fortify
+  module ActiveRecord
+    module Scoping
+      extend ActiveSupport::Concern
+
+      def populate_with_current_scope_attributes # :nodoc:
+        return
+      end
+    end
+  end
+end

--- a/lib/fortify/activerecord/validation.rb
+++ b/lib/fortify/activerecord/validation.rb
@@ -14,6 +14,7 @@ module Fortify
       end
 
       private
+
       def check_if_creatable
         return if Fortify.disabled?
 

--- a/lib/fortify/base.rb
+++ b/lib/fortify/base.rb
@@ -37,7 +37,8 @@ module Fortify
     end
 
     def self.scope(&block)
-      Scope.send(:define_method, :resolve, &block)
+      #Define Scope subclass on policy class with Fortify::Base::Scope as parent class and override resolve method
+      self.const_set("Scope", Class.new(Scope)).send(:define_method, :resolve, &block)
     end
   end
 end

--- a/spec/support/policies.rb
+++ b/spec/support/policies.rb
@@ -12,7 +12,7 @@ class ApplicationPolicy < Fortify::Base
   end
 
   def create?
-    user.admin?
+    true
   end
 
   def new?


### PR DESCRIPTION
* ActiveRecord::Scoping contains a method named
```populate_with_current_scope_attributes``` that adds the current scope
to the record if one exists. This overrides that method and simply
returns without adding the default scope attributes, preventing them
from being set on save