### PR TITLE
Adding `can?` method for easier permission checks

### DIFF
--- a/fortify.gemspec
+++ b/fortify.gemspec
@@ -38,6 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry", "~> 0.11.0"
   spec.add_development_dependency "pry-byebug", "~> 3.5.0"
   spec.add_development_dependency "rspec_junit_formatter"
+  spec.add_development_dependency "simplecov", "~> 0.15.1"
 
   spec.add_runtime_dependency "activerecord", "~> 5.0.2"
   spec.add_runtime_dependency 'activesupport', '~> 5.0.2'

--- a/lib/fortify/activerecord/base.rb
+++ b/lib/fortify/activerecord/base.rb
@@ -11,8 +11,23 @@ module Fortify
         end
       end
 
+      def can?(action, field=nil)
+        return false unless policy.respond_to?("#{action}?") && policy.public_send("#{action}?")
+        return true unless field.present?
+
+        method_name = if policy.respond_to?("permitted_attributes_for_#{action}")
+            "permitted_attributes_for_#{action}"
+          else
+            "permitted_attributes"
+          end
+
+        permitted_attributes = policy.public_send(method_name).map(&:to_s)
+
+        return permitted_attributes.include?(field.to_s)
+      end
+
       def policy
-        Fortify.policy(self)
+        @policy ||= Fortify.policy(self)
       end
     end
   end

--- a/lib/fortify/activerecord/validation.rb
+++ b/lib/fortify/activerecord/validation.rb
@@ -8,14 +8,13 @@ module Fortify
       included do
         before_validation :check_if_creatable, on: :create
         before_validation :check_if_updatable, on: :update
-        before_validation :check_attribute_on_create, on: :create
-        before_validation :check_attribute_on_update, on: :update
+        before_validation :check_attribute_for_create, on: :create
+        before_validation :check_attribute_for_update, on: :update
         before_destroy :check_if_destroyable
       end
 
       private
       def check_if_creatable
-        binding.pry
         return if Fortify.disabled?
 
         unless policy.create?
@@ -40,20 +39,20 @@ module Fortify
         end
       end
 
-      def check_attribute_on_create
+      def check_attribute_for_create
         return if Fortify.disabled?
 
-        attrs = changed_attributes.keys - policy.permitted_attributes_on_create.map(&:to_s)
+        attrs = changed_attributes.keys - policy.permitted_attributes_for_create.map(&:to_s)
 
         attrs.each do |attr|
           errors.add(attr, MESSAGE)
         end
       end
 
-      def check_attribute_on_update
+      def check_attribute_for_update
         return if Fortify.disabled?
 
-        attrs = changed_attributes.keys - policy.permitted_attributes_on_update.map(&:to_s)
+        attrs = changed_attributes.keys - policy.permitted_attributes_for_update.map(&:to_s)
 
         attrs.each do |attr|
           errors.add(attr, MESSAGE)

--- a/lib/fortify/base.rb
+++ b/lib/fortify/base.rb
@@ -6,11 +6,11 @@ module Fortify
       []
     end
 
-    def permitted_attributes_on_create
+    def permitted_attributes_for_update
       []
     end
 
-    def permitted_attributes_on_update
+    def permitted_attributes_for_create
       []
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,6 @@
+require "simplecov"
+SimpleCov.start
+
 require "bundler/setup"
 require "fortify"
 require "pry"

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -1,17 +1,17 @@
 #USERS
-default_user = User.create!(name: "default-user")
-partner_user = User.create!(name: "partner-user")
-other_user = User.create!(name: "other-user")
-admin_user = User.create!(name: "admin-user", admin: true)
+default_user = User.create!(name: "default-user", text: "This is the default user")
+partner_user = User.create!(name: "partner-user", text: "This is the partner user")
+other_user = User.create!(name: "other-user", text: "This is another user")
+admin_user = User.create!(name: "admin-user", admin: true, text: "This is the admin user")
 
 #PROJECTS
-default_project = Project.create!(name: "Default Project")
-other_project = Project.create!(name: "Another Project")
+default_project = Project.create!(name: "Default Project", text: "This is the default project", number: 999)
+other_project = Project.create!(name: "Another Project", text: "This is another project", number: 123)
 
 #TASKS
-default_task = Task.create!(project: default_project, name: "Default Task")
-personal_task = Task.create!(project: default_project, name: "Personal Task", personal: true, user: default_user)
-other_task = Task.create!(project: other_project, name: "Another Task")
+default_task = Task.create!(project: default_project, name: "Default Task", text: "This is the default task")
+personal_task = Task.create!(project: default_project, name: "Personal Task", personal: true, user: default_user, text: "This is the personal task")
+other_task = Task.create!(project: other_project, name: "Another Task", text: "This is another task")
 
 #PROJECT USERS
 ProjectUser.create!(user: default_user, project: default_project)

--- a/spec/support/policies.rb
+++ b/spec/support/policies.rb
@@ -1,9 +1,13 @@
 class ApplicationPolicy < Fortify::Base
   def index?
-    true
+    read?
   end
 
   def show?
+    read?
+  end
+
+  def read?
     true
   end
 
@@ -29,8 +33,12 @@ class ApplicationPolicy < Fortify::Base
 end
 
 class ProjectPolicy < ApplicationPolicy
-  def permitted_attributes_on_update
-    [:name, :text]
+  def permitted_attributes_for_read
+    %i(id name number text)
+  end
+
+  def permitted_attributes_for_update
+    %i(name text)
   end
 
   class Scope < Scope
@@ -45,6 +53,10 @@ class ProjectPolicy < ApplicationPolicy
 end
 
 class TaskPolicy < ApplicationPolicy
+  def permitted_attributes_for_read
+    %i(id name number text personal project_id user_id)
+  end
+
   class Scope < Scope
     def resolve
       if user.admin?
@@ -60,6 +72,10 @@ class TaskPolicy < ApplicationPolicy
 end
 
 class UserPolicy < ApplicationPolicy
+  def permitted_attributes_for_read
+    %i(id name number text)
+  end
+
   class Scope < Scope
     def resolve
       if user.admin?


### PR DESCRIPTION
- It's brittle to do what Protector does for read permission, which is nil out unreadable attributes.
  Here we are expected to call `can? :read, {field}` during serialization in order to filter unreadable attributes.
- Change `permitted_attribute_on_#{action}` to `permitted_attribute_for_#{action}` to be aligned with Punit
- Adding SimpleCov to code coverage