### PR TITLE
Proxy `can?` in ActiveRecord to its policy class

### DIFF
--- a/lib/fortify.rb
+++ b/lib/fortify.rb
@@ -20,7 +20,6 @@ module Fortify
   class << self
     def set_user(user)
       self.user = user
-
       policies.each { |policy| policy.setup_permission(user) }
     end
 
@@ -33,6 +32,7 @@ module Fortify
     end
 
     def policy(record)
+      # TODO: raise a detailed exception when there is no user set
       Pundit.policy(user, record)
     end
 

--- a/lib/fortify/activerecord/base.rb
+++ b/lib/fortify/activerecord/base.rb
@@ -13,11 +13,7 @@ module Fortify
       end
 
       def can?(action, field=nil)
-        if field.present?
-          policy.send("permitted_attributes_for_#{action}").map(&:to_s).include?(field.to_s)
-        else
-          policy.access_map.keys.include?(action.to_s)
-        end
+        policy.can?(action, field)
       end
 
       def policy


### PR DESCRIPTION
So that we can do `policy.can?(:read)` as well as `UserPolicy.can?(:read)`

- Adding ability to set model class on policy
- Setting scope_proc default